### PR TITLE
Performance optimization

### DIFF
--- a/htdocs/luci-static/resources/view/geomate/geofilters.js
+++ b/htdocs/luci-static/resources/view/geomate/geofilters.js
@@ -196,6 +196,12 @@ return view.extend({
         s.addremove = true;  // Allow adding and removing filters
         s.anonymous = true;
 
+        // Enable/disable individual filters
+        o = s.option(form.Flag, 'enabled', _('Enable'));
+        o.editable = true;
+        o.rmempty = false;
+        o.default = '1';
+
         // Filter name identifier
         o = s.option(form.Value, 'name', _('Name'));
         o.rmempty = false;
@@ -260,11 +266,6 @@ return view.extend({
         // Geographic regions that are allowed for this filter
         o = s.option(form.DynamicList, 'allowed_region', _('Allowed Regions'));
         o.rmempty = true;
-
-        // Enable/disable individual filters
-        o = s.option(form.Flag, 'enabled', _('Enable'));
-        o.rmempty = false;
-        o.default = '1';
 
         // Protocol selection (TCP/UDP)
         o = s.option(form.ListValue, 'protocol', _('Protocol'));

--- a/htdocs/luci-static/resources/view/geomate/geofilters.js
+++ b/htdocs/luci-static/resources/view/geomate/geofilters.js
@@ -298,6 +298,16 @@ return view.extend({
         o = s.option(form.Value, 'ip_list', _('IP List File'));
         o.rmempty = false;
 
+        // IP expiry days - removes inactive IPs after specified days
+        o = s.option(form.Value, 'ip_expiry_days', _('IP Expiry (Days)'),
+            _('Automatically remove IPs not seen for this many days. Set to 0 to disable. ' +
+              'Useful for games with dynamic servers where IPs change frequently.'));
+        o.datatype = 'uinteger';
+        o.placeholder = '0';
+        o.default = '0';  // Default for existing filters: disabled
+        o.rmempty = true;
+        o.modalonly = true;
+
         // Helper function to generate and set the IP list path
         function setIpListPath(section_id, map) {
             var name_field = map.lookupOption('name', section_id)[0];


### PR DESCRIPTION
- Reposition the per-filter "Enable" Flag to the top of the geofilter form
- Add expiry days - removes inactive IPs after specified days